### PR TITLE
Feat claim window

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "whoami-paths"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "cosmwasm-schema",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whoami-paths"
-version = "1.0.0"
+version = "1.1.0"
 authors = ["callumanderson <callumanderson745@gmail.com>"]
 edition = "2018"
 

--- a/schema/config.json
+++ b/schema/config.json
@@ -4,11 +4,25 @@
   "type": "object",
   "required": [
     "admin",
+    "initial_height",
     "whoami_address"
   ],
   "properties": {
     "admin": {
       "$ref": "#/definitions/Addr"
+    },
+    "initial_height": {
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "path_root_claim_blocks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
     },
     "token_id": {
       "type": [

--- a/schema/config.json
+++ b/schema/config.json
@@ -16,7 +16,7 @@
       "format": "uint64",
       "minimum": 0.0
     },
-    "path_root_claim_blocks": {
+    "reserve_root_for_n_blocks": {
       "type": [
         "integer",
         "null"

--- a/schema/config.json
+++ b/schema/config.json
@@ -5,6 +5,7 @@
   "required": [
     "admin",
     "initial_height",
+    "reserve_root_names",
     "whoami_address"
   ],
   "properties": {
@@ -23,6 +24,9 @@
       ],
       "format": "uint64",
       "minimum": 0.0
+    },
+    "reserve_root_names": {
+      "type": "boolean"
     },
     "token_id": {
       "type": [

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -10,6 +10,14 @@
     "admin": {
       "type": "string"
     },
+    "path_root_claim_blocks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
+    },
     "payment_details": {
       "anyOf": [
         {

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -4,6 +4,7 @@
   "type": "object",
   "required": [
     "admin",
+    "reserve_root_names",
     "whoami_address"
   ],
   "properties": {
@@ -27,6 +28,9 @@
       ],
       "format": "uint64",
       "minimum": 0.0
+    },
+    "reserve_root_names": {
+      "type": "boolean"
     },
     "whoami_address": {
       "type": "string"

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -10,14 +10,6 @@
     "admin": {
       "type": "string"
     },
-    "path_root_claim_blocks": {
-      "type": [
-        "integer",
-        "null"
-      ],
-      "format": "uint64",
-      "minimum": 0.0
-    },
     "payment_details": {
       "anyOf": [
         {
@@ -27,6 +19,14 @@
           "type": "null"
         }
       ]
+    },
+    "reserve_root_for_n_blocks": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint64",
+      "minimum": 0.0
     },
     "whoami_address": {
       "type": "string"

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -37,6 +37,26 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "claim_info"
+      ],
+      "properties": {
+        "claim_info": {
+          "type": "object",
+          "required": [
+            "path"
+          ],
+          "properties": {
+            "path": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -150,7 +150,7 @@ pub fn instantiate(
         admin: admin.clone(),
         token_id: None,
         initial_height: env.block.height,
-        path_root_claim_blocks: msg.path_root_claim_blocks,
+        reserve_root_for_n_blocks: msg.reserve_root_for_n_blocks,
     };
 
     CONFIG.save(deps.storage, &config)?;
@@ -227,7 +227,7 @@ pub fn execute_receive_cw20(
     };
 
     let is_in_claim_window_ = is_in_claim_window(
-        config.path_root_claim_blocks,
+        config.reserve_root_for_n_blocks,
         config.initial_height,
         env.block.height,
     );
@@ -314,7 +314,7 @@ pub fn execute_mint_path(
     let token_id = config.token_id.unwrap();
 
     let is_in_claim_window_ = is_in_claim_window(
-        config.path_root_claim_blocks,
+        config.reserve_root_for_n_blocks,
         config.initial_height,
         env.block.height,
     );
@@ -534,7 +534,7 @@ pub fn query_claim_info(deps: Deps, env: Env, path: String) -> StdResult<Binary>
 
     to_binary(&ClaimInfoResponse {
         is_in_claim_window: is_in_claim_window(
-            config.path_root_claim_blocks,
+            config.reserve_root_for_n_blocks,
             config.initial_height,
             env.block.height,
         ),
@@ -561,7 +561,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
         token_id: config_v100.token_id,
         whoami_address: config_v100.whoami_address,
         initial_height: env.block.height,
-        path_root_claim_blocks: msg.path_root_claim_blocks,
+        reserve_root_for_n_blocks: msg.reserve_root_for_n_blocks,
     };
 
     CONFIG.save(deps.storage, &config)?;
@@ -569,9 +569,9 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
     Ok(Response::new()
         .add_attribute("action", "migrate")
         .add_attribute(
-            "path_root_claim_blocks",
+            "reserve_root_for_n_blocks",
             config
-                .path_root_claim_blocks
+                .reserve_root_for_n_blocks
                 .unwrap_or_default()
                 .to_string(),
         ))

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -150,6 +150,7 @@ pub fn instantiate(
         admin: admin.clone(),
         token_id: None,
         initial_height: env.block.height,
+        reserve_root_names: msg.reserve_root_names,
         reserve_root_for_n_blocks: msg.reserve_root_for_n_blocks,
     };
 
@@ -233,6 +234,10 @@ pub fn execute_receive_cw20(
     );
 
     if is_in_claim_window_ {
+        if !config.reserve_root_names {
+            return Err(ContractError::ReserveRootNameDisabled {});
+        }
+
         let path_as_base_owner =
             get_dens_owner(&deps.querier, path.clone(), config.whoami_address.clone());
 
@@ -320,6 +325,10 @@ pub fn execute_mint_path(
     );
 
     if is_in_claim_window_ {
+        if !config.reserve_root_names {
+            return Err(ContractError::ReserveRootNameDisabled {});
+        }
+
         let path_as_base_owner =
             get_dens_owner(&deps.querier, path.clone(), config.whoami_address.clone());
 
@@ -561,6 +570,7 @@ pub fn migrate(deps: DepsMut, env: Env, msg: MigrateMsg) -> Result<Response, Con
         token_id: config_v100.token_id,
         whoami_address: config_v100.whoami_address,
         initial_height: env.block.height,
+        reserve_root_names: msg.reserve_root_names,
         reserve_root_for_n_blocks: msg.reserve_root_for_n_blocks,
     };
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,4 +36,7 @@ pub enum ContractError {
 
     #[error("The token address provided is not a valid CW20 token")]
     InvalidCw20 {},
+
+    #[error("For the path exists root token with same name")]
+    RootInClaimWindowToken {},
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -37,6 +37,9 @@ pub enum ContractError {
     #[error("The token address provided is not a valid CW20 token")]
     InvalidCw20 {},
 
+    #[error("Reserve root names disabled")]
+    ReserveRootNameDisabled {},
+
     #[error("For the path exists root token with same name")]
     RootInClaimWindowToken {},
 }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -135,6 +135,7 @@ mod tests {
             admin: ADMIN.to_string(),
             whoami_address: whoami_addr.to_string(),
             payment_details,
+            path_root_claim_blocks: None,
         };
         app.instantiate_contract(
             whoami_paths,

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -1180,6 +1180,23 @@ mod tests {
         }
 
         #[test]
+        fn test_mint_path_existing_root_owner_claim_window_passed() {
+            let mut app = mock_app();
+            let (whoami, paths, token_id) = setup_test_case_with_name(&mut app, None, Some(1));
+
+            // Mint the name
+            let root_token_id = "another_root".to_string();
+            mint_name(&mut app, whoami.clone(), USER, &root_token_id).unwrap();
+
+            let path = root_token_id.clone();
+
+            mint_path_native(&mut app, paths, USER2, &path, vec![]).unwrap();
+
+            let resp = get_nft_owner(&mut app, whoami, format!("{}::{}", token_id, path));
+            assert_eq!(resp.owner, USER2.to_string());
+        }
+
+        #[test]
         #[should_panic(expected = "This message does no accept funds")]
         fn test_mint_path_pay_native() {
             let mut app = mock_app();
@@ -1222,6 +1239,30 @@ mod tests {
             let path = root_token_id.clone();
 
             mint_path_cw20(&mut app, cw20_addr, paths, USER, Uint128::new(100), &path).unwrap();
+        }
+
+        #[test]
+        fn test_mint_path_pay_cw20_passed_claim_window() {
+            let mut app = mock_app();
+            let cw20_addr = instantiate_cw20(&mut app);
+            let (whoami, paths, token_id) = setup_test_case_with_name(
+                &mut app,
+                Some(PaymentDetails::Cw20 {
+                    token_address: cw20_addr.to_string(),
+                    amount: Uint128::new(100),
+                }),
+                Some(1),
+            );
+
+            // Mint the name
+            let root_token_id = "another_root".to_string();
+            mint_name(&mut app, whoami.clone(), USER, &root_token_id).unwrap();
+
+            let path = root_token_id.clone();
+
+            mint_path_cw20(&mut app, cw20_addr, paths, USER, Uint128::new(100), &path).unwrap();
+            let resp = get_nft_owner(&mut app, whoami, format!("{}::{}", token_id, path));
+            assert_eq!(resp.owner, USER.to_string());
         }
     }
 }

--- a/src/integration_tests.rs
+++ b/src/integration_tests.rs
@@ -147,14 +147,14 @@ mod tests {
         app: &mut App,
         whoami_addr: Addr,
         payment_details: Option<PaymentDetails>,
-        path_root_claim_blocks: Option<u64>,
+        reserve_root_for_n_blocks: Option<u64>,
     ) -> Addr {
         let whoami_paths = app.store_code(contract_whoami_paths());
         let msg = InstantiateMsg {
             admin: ADMIN.to_string(),
             whoami_address: whoami_addr.to_string(),
             payment_details,
-            path_root_claim_blocks,
+            reserve_root_for_n_blocks,
         };
         app.instantiate_contract(
             whoami_paths,
@@ -170,14 +170,14 @@ mod tests {
     fn setup_test_case(
         app: &mut App,
         payment_details: Option<PaymentDetails>,
-        path_root_claim_blocks: Option<u64>,
+        reserve_root_for_n_blocks: Option<u64>,
     ) -> (Addr, Addr) {
         let whoami_addr = instantiate_whoami(app);
         let paths_addr = instantiate_whoami_paths(
             app,
             whoami_addr.clone(),
             payment_details,
-            path_root_claim_blocks,
+            reserve_root_for_n_blocks,
         );
         app.update_block(next_block);
         (whoami_addr, paths_addr)
@@ -186,9 +186,9 @@ mod tests {
     fn setup_test_case_with_name(
         app: &mut App,
         payment_details: Option<PaymentDetails>,
-        path_root_claim_blocks: Option<u64>,
+        reserve_root_for_n_blocks: Option<u64>,
     ) -> (Addr, Addr, String) {
-        let (whoami, paths) = setup_test_case(app, payment_details, path_root_claim_blocks);
+        let (whoami, paths) = setup_test_case(app, payment_details, reserve_root_for_n_blocks);
 
         // Mint the name
         let token_id = "root_name".to_string();

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,6 +22,7 @@ pub struct InstantiateMsg {
     pub admin: String,          // Only the admin can withdraw the name if needed
     pub whoami_address: String, // Address of base whoami contract
     pub payment_details: Option<PaymentDetails>, // Users may have to pay in a cw20 or a native token
+    pub path_root_claim_blocks: Option<u64>, // Allow users with (de)NS root token to claim the path
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -47,6 +48,7 @@ pub enum QueryMsg {
     Config {},
     PaymentDetails {},
     PaymentDetailsBalance {},
+    ClaimInfo { path: String },
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -60,4 +62,11 @@ pub struct PaymentDetailsResponse {
 pub struct PaymentDetailsBalanceResponse {
     pub payment_details: Option<PaymentDetails>,
     pub amount: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct ClaimInfoResponse {
+    pub is_in_claim_window: bool,
+    pub path_as_base_owner: Option<String>,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -70,3 +70,9 @@ pub struct ClaimInfoResponse {
     pub is_in_claim_window: bool,
     pub path_as_base_owner: Option<String>,
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub struct MigrateMsg {
+    pub path_root_claim_blocks: Option<u64>,
+}

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -21,6 +21,7 @@ pub enum PaymentDetails {
 pub struct InstantiateMsg {
     pub admin: String,          // Only the admin can withdraw the name if needed
     pub whoami_address: String, // Address of base whoami contract
+    pub reserve_root_names: bool,
     pub payment_details: Option<PaymentDetails>, // Users may have to pay in a cw20 or a native token
     pub reserve_root_for_n_blocks: Option<u64>, // Allow users with (de)NS root token to claim the path
 }
@@ -74,5 +75,6 @@ pub struct ClaimInfoResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
+    pub reserve_root_names: bool,
     pub reserve_root_for_n_blocks: Option<u64>,
 }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -22,7 +22,7 @@ pub struct InstantiateMsg {
     pub admin: String,          // Only the admin can withdraw the name if needed
     pub whoami_address: String, // Address of base whoami contract
     pub payment_details: Option<PaymentDetails>, // Users may have to pay in a cw20 or a native token
-    pub path_root_claim_blocks: Option<u64>, // Allow users with (de)NS root token to claim the path
+    pub reserve_root_for_n_blocks: Option<u64>, // Allow users with (de)NS root token to claim the path
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -74,5 +74,5 @@ pub struct ClaimInfoResponse {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct MigrateMsg {
-    pub path_root_claim_blocks: Option<u64>,
+    pub reserve_root_for_n_blocks: Option<u64>,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,8 @@ pub struct Config {
     pub whoami_address: String,
     pub admin: Addr,
     pub token_id: Option<String>, // If we have received a name to mint paths off this will be the token_id
+    pub path_root_claim_blocks: Option<u64>,
+    pub initial_height: u64,
 }
 
 pub const CONFIG: Item<Config> = Item::new("config");

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,7 @@ pub struct Config {
     pub whoami_address: String,
     pub admin: Addr,
     pub token_id: Option<String>, // If we have received a name to mint paths off this will be the token_id
-    pub path_root_claim_blocks: Option<u64>,
+    pub reserve_root_for_n_blocks: Option<u64>,
     pub initial_height: u64,
 }
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,6 +10,7 @@ pub struct Config {
     pub whoami_address: String,
     pub admin: Addr,
     pub token_id: Option<String>, // If we have received a name to mint paths off this will be the token_id
+    pub reserve_root_names: bool,
     pub reserve_root_for_n_blocks: Option<u64>,
     pub initial_height: u64,
 }


### PR DESCRIPTION
This change introduces the ability for the mint-path contract to define a number of blocks as the claim period. During this period, the path is checked to see if it exists as a root (de)NS domain.

If the root does exist and the minter is not the owner of the root domain, execution is forbidden. However, if the minter is the owner of the root domain, minting is free during the claim period. On the other hand, if the path doesn't exist as the root domain, the minting process will proceed as usual.

For example, if the root domain is `username` and another domain `howlpack` exists, and if the whoami-paths contains `username` NFT and the `attribute path_root_claim_blocks` is defined, then for the amount of blocks nobody can mint `username::howlpack` except for the owner of the `howlpack` root domain. The owner can do it for free even though the minting is paid.

After the amount of blocks have passed, then anyone can mint `username::howlpack`. However, they will have to pay for it as defined in the whoami-path contract, even the owner of the `howlpack` domain.